### PR TITLE
[weave-scope] fixing operator and weave scope access resource error. 

### DIFF
--- a/deploy/upstream/04-clusterrole.yaml
+++ b/deploy/upstream/04-clusterrole.yaml
@@ -157,4 +157,71 @@ rules:
   - horizontalpodautoscalers
   verbs:
   - list
-
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  - replicationcontrollers
+  - services
+  - nodes
+  - persistentvolumes
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/scale
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - deployments/scale
+  verbs:
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - "*"
+- apiGroups:
+  - extensions
+  resourceNames:
+  - federatorai-alameda-weave-scope
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
+  - volumesnapshot.external-storage.k8s.io
+  resources:
+  - volumesnapshots
+  - volumesnapshotdatas
+  verbs:
+  - list
+  - watch

--- a/deploy/upstream/06-role.yaml
+++ b/deploy/upstream/06-role.yaml
@@ -37,4 +37,71 @@ rules:
   verbs:
   - create
   - get
-
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  - replicationcontrollers
+  - services
+  - nodes
+  - persistentvolumes
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments
+  - deployments/scale
+  - replicasets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - deployments/scale
+  verbs:
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - "*"
+- apiGroups:
+  - extensions
+  resourceNames:
+  - federatorai-alameda-weave-scope
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+- apiGroups:
+  - volumesnapshot.external-storage.k8s.io
+  resources:
+  - volumesnapshots
+  - volumesnapshotdatas
+  verbs:
+  - list
+  - watch


### PR DESCRIPTION
1. fixing operator can't access PodSecurityPolicy resource.
1. fixing weave scope can't access daemonset, pod/logs, persistentvolumes, etc. resources.